### PR TITLE
added bot beer me via hubot-beer-me to resolve issue #1

### DIFF
--- a/external-scripts.json
+++ b/external-scripts.json
@@ -11,5 +11,6 @@
   "hubot-shipit",
   "hubot-youtube",
   "hubot-fliptable",
-  "hubot-plusplus"
+  "hubot-plusplus",
+  "hubot-beer-me"
 ]

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "ascii-table": "0.0.8",
     "es6-promise": "^2.0.1",
     "hubot": "^2.9.3",
+    "hubot-beer-me": "^0.1.2",
     "hubot-diagnostics": "0.0.1",
     "hubot-fliptable": "^1.2.0",
     "hubot-google-images": "^0.1.0",


### PR DESCRIPTION
I found a wheel.  I didn't invent this.

beeradvocate and ratebeer APIs are now defunct.  brewerydb has no user ratings, but has good technical info.  Limit 400 calls/day with free API key.  Key to be PMd to @sethetter for deployment.

`heroku config:add BREWERYDB_KEY=abcxyzhitjimsprivateapiKey`