### PR TITLE
A bit more safety in die rolling

### DIFF
--- a/scripts/roll-for.coffee
+++ b/scripts/roll-for.coffee
@@ -23,49 +23,49 @@ module.exports = (robot) ->
     else
       msg.send("#{username} rolled a #{number} for #{reason}.")
 
-  robot.respond /roll (\d+)d(\d+)/i, (msg) ->
+  robot.respond /roll (\d+)d(\d+)( for .+)?/i, (msg) ->
     total = 0
     number_of_dice = parseInt(msg.match[1])
     number_of_sides = parseInt(msg.match[2])
     username = msg.message.user.name
-
-    roll_summary = "[ "
+    roll_log = []
 
     if number_of_dice > 0 
       while number_of_dice != 0
         the_roll = roll_a_die(number_of_sides)
         total += the_roll
-        roll_summary += the_roll + ", "
+        roll_log.push(the_roll)
         number_of_dice--
 
-      roll_summary = roll_summary.substring(0, roll_summary.length-1)
+    roll_summary = ""
+    if roll_log.length > 1
+      roll_summary = "[ "
+      i = 0
 
-    roll_summary += " ]"
+      if roll_log.length > number_of_sides
+        num_rolls_hash = { } 
+        while i < roll_log.length
+          k = roll_log[i++]
+          if !num_rolls_hash[k]?
+            num_rolls_hash[k] = 0
+          num_rolls_hash[k]++     
+        for k,v of num_rolls_hash
+          roll_summary += k + ": " + v + ", " 
+      else
+        while i < roll_log.length
+          roll_summary += roll_log[i++] + ", "
 
-    msg.send("#{username} rolled a total of #{total} " + roll_summary)
+      roll_summary = roll_summary.substring(0, roll_summary.length - 2) + " ]"
 
-  robot.respond /roll (\d+)d(\d+) for (.+)/i, (msg) ->
-    total = 0
-    number_of_dice = parseInt(msg.match[1])
-    number_of_sides = parseInt(msg.match[2])
-    reason = msg.match[3]
-    username = msg.message.user.name
-    roll_summary = "[ "
+    reason = ""
 
-    if number_of_dice > 0 
-      while number_of_dice != 0
-        the_roll = roll_a_die(number_of_sides)
-        total += the_roll
-        roll_summary += the_roll + ", "
-        number_of_dice--
+    if msg.match[3]?
+      reason = msg.match[3]
 
-      roll_summary = roll_summar.substring(0, roll_summary.length-1)
-
-    roll_summary += " ]"
-    msg.send("#{username} rolled a total of #{total} for #{reason} " + roll_summary)
+    msg.send("#{username} rolled a total of #{total}#{reason} #{roll_summary}")
 
   roll_a_die = (number_of_sides) ->
-    if !number_of_sides.isNaN() && number_of_sides < Infinity
+    if !isNaN(number_of_sides)
       return Math.floor(Math.random() * parseInt(number_of_sides))+1
 
     return 0

--- a/scripts/roll-for.coffee
+++ b/scripts/roll-for.coffee
@@ -10,6 +10,7 @@
 # Commands:
 #   bot roll for <whatever>
 #   bot roll <number of dice>d<sides> for <whatever> - e.g. roll 1d6 for coding
+#   bot roll <number of dice>d<sides> - e.g. roll 1d6
 
 module.exports = (robot) ->
   robot.respond /roll for (.+)/i, (msg) ->
@@ -22,22 +23,50 @@ module.exports = (robot) ->
     else
       msg.send("#{username} rolled a #{number} for #{reason}.")
 
-  robot.respond /roll (.+)d(.+) for (.+)/i, (msg) ->
+  robot.respond /roll (\d+)d(\d+)/i, (msg) ->
+    total = 0
+    number_of_dice = parseInt(msg.match[1])
+    number_of_sides = parseInt(msg.match[2])
+    username = msg.message.user.name
+
+    roll_summary = "[ "
+
+    if number_of_dice > 0 
+      while number_of_dice != 0
+        the_roll = roll_a_die(number_of_sides)
+        total += the_roll
+        roll_summary += the_roll + ", "
+        number_of_dice--
+
+      roll_summary = roll_summary.substring(0, roll_summary.length-1)
+
+    roll_summary += " ]"
+
+    msg.send("#{username} rolled a total of #{total} " + roll_summary)
+
+  robot.respond /roll (\d+)d(\d+) for (.+)/i, (msg) ->
     total = 0
     number_of_dice = parseInt(msg.match[1])
     number_of_sides = parseInt(msg.match[2])
     reason = msg.match[3]
     username = msg.message.user.name
+    roll_summary = "[ "
 
-    while number_of_dice != 0
-      the_roll = roll_a_die(number_of_sides)
-      total += the_roll
-      msg.send("#{username} rolls 1 d#{number_of_sides} for #{the_roll}")
-      number_of_dice--
+    if number_of_dice > 0 
+      while number_of_dice != 0
+        the_roll = roll_a_die(number_of_sides)
+        total += the_roll
+        roll_summary += the_roll + ", "
+        number_of_dice--
 
-    msg.send("#{username} rolled a total of #{total} for #{reason}")
+      roll_summary = roll_summar.substring(0, roll_summary.length-1)
 
-
+    roll_summary += " ]"
+    msg.send("#{username} rolled a total of #{total} for #{reason} " + roll_summary)
 
   roll_a_die = (number_of_sides) ->
-    Math.floor(Math.random() * parseInt(number_of_sides))+1
+    if !number_of_sides.isNaN() && number_of_sides < Infinity
+      return Math.floor(Math.random() * parseInt(number_of_sides))+1
+
+    return 0
+    


### PR DESCRIPTION
* Adjusted regex to only allow digits in <num>d<num>
* Put optional region in regex
* Instead of 1 message per die roll, just include a summary after the reason
* When rolling more dice than there are sides, display a summary of how many of each side came up instead of each roll.