### PR TITLE
Add giphy integration; remove google images integration

### DIFF
--- a/external-scripts.json
+++ b/external-scripts.json
@@ -2,7 +2,6 @@
   "hubot-diagnostics",
   "hubot-heroku-keepalive",
   "hubot-giphy-gifme",
-  "hubot-google-images",
   "hubot-google-translate",
   "hubot-pugme",
   "hubot-maps",

--- a/external-scripts.json
+++ b/external-scripts.json
@@ -1,6 +1,7 @@
 [
   "hubot-diagnostics",
   "hubot-heroku-keepalive",
+  "hubot-giphy-gifme",
   "hubot-google-images",
   "hubot-google-translate",
   "hubot-pugme",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "hubot-beer-me": "^0.1.2",
     "hubot-diagnostics": "0.0.1",
     "hubot-fliptable": "^1.2.0",
+    "hubot-giphy-gifme": "^1.0.0",
     "hubot-google-images": "^0.1.0",
     "hubot-google-translate": "^0.1.0",
     "hubot-heroku-keepalive": "0.0.4",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "hubot-diagnostics": "0.0.1",
     "hubot-fliptable": "^1.2.0",
     "hubot-giphy-gifme": "^1.0.0",
-    "hubot-google-images": "^0.1.0",
     "hubot-google-translate": "^0.1.0",
     "hubot-heroku-keepalive": "0.0.4",
     "hubot-maps": "0.0.0",


### PR DESCRIPTION
I have not requested a giphy API key yet, but it is required for deployment, I figure it should probably connect to a DevICT email account.

The Heroku environment variable for the API key that needs to be set by an admin is HUBOT_GIPHY_API_KEY. It defaults to PG gifs, which probably suffices for the DevICT code of conduct.

https://github.com/bencentra/hubot-giphy-gifme
