### PR TITLE
Added coffeescript installation step to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ This README is intended to help get you started. Definitely update and improve t
 
 You can test your hubot by running the following.
 
+First, make sure that CoffeeScript is installed. The version should be 1.11.1 or less, since version 2 introduces some breaking changes to the current hubot code.
+
+    % npm install --global coffeescript@1.11.1
+
 You can start devict-hubot locally by running:
 
     % bin/hubot


### PR DESCRIPTION
I had trouble running hubot for local testing until I figured out I had to install the correct version of coffee-script.